### PR TITLE
mediatek: battery: Report the voltage in the correct scale

### DIFF
--- a/kernel-3.10/drivers/power/mediatek/battery_common.c
+++ b/kernel-3.10/drivers/power/mediatek/battery_common.c
@@ -1763,7 +1763,7 @@ static void battery_update(struct battery_data *bat_data)
 
 	bat_data->BAT_TECHNOLOGY = POWER_SUPPLY_TECHNOLOGY_LION;
 	bat_data->BAT_HEALTH = POWER_SUPPLY_HEALTH_GOOD;
-	bat_data->BAT_batt_vol = BMT_status.bat_vol;
+	bat_data->BAT_batt_vol = BMT_status.bat_vol * 1000;
 	bat_data->BAT_batt_temp = BMT_status.temperature * 10;
 	bat_data->BAT_PRESENT = BMT_status.bat_exist;
 
@@ -3661,7 +3661,7 @@ static int battery_probe(struct platform_device *dev)
 		battery_main.BAT_PRESENT = 1;
 		battery_main.BAT_TECHNOLOGY = POWER_SUPPLY_TECHNOLOGY_LION;
 		battery_main.BAT_CAPACITY = 100;
-		battery_main.BAT_batt_vol = 4200;
+		battery_main.BAT_batt_vol = 4200000;
 		battery_main.BAT_batt_temp = 220;
 
 		g_bat_init_flag = KAL_TRUE;


### PR DESCRIPTION
The framework expects microvolts but we were reporting millivolts.
